### PR TITLE
Added more error handling

### DIFF
--- a/src/processors/nycProcessor.js
+++ b/src/processors/nycProcessor.js
@@ -30,9 +30,14 @@ class NycProcessor extends BaseProcessor {
         var city = filters.city ? filters.city.toUpperCase() : '*';
 
         const queryUrl = this._queryUrlTemplate;
-        const result = await axios.get(queryUrl);
 
-        if (result.status === 200) {
+        var result = await axios.get(queryUrl)
+        .catch(function(err) {
+            console.log(`fetchVaccineInfo threw error: ${err}`);
+            result = null;
+        });
+
+        if (result && result.status === 200) {
             // Cheerio experimental for now
             // const htmlData = result.data;
             // const $ = cheerio.load(htmlData);


### PR DESCRIPTION
Error handling was a bit of an after-thought, but since the NYC URL went down it's caused the API to crash. Added some temporary handling until we can redo the handling code.